### PR TITLE
Fix organization name typo hydroserver2/hydroserver#32

### DIFF
--- a/core/endpoints/thing/schemas.py
+++ b/core/endpoints/thing/schemas.py
@@ -33,7 +33,7 @@ class LocationFields(Schema):
 
 
 class OrganizationFields(Schema):
-    organization_name: Optional[str] = Field(None, alias='organizationName')
+    name: Optional[str] = Field(None, alias='organizationName')
 
 
 class AssociationFields(Schema):


### PR DESCRIPTION
Looks like the problem was just naming the key wrong to get organization.name put in the response body