### PR TITLE
Added CreateObservations endpoint.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 
   - pip:
       - Authlib==1.2.1
-      - hydroserver-sensorthings==0.2.3
+      - hydroserver-sensorthings==0.2.4
       - django-ninja-jwt==5.2.5
       - hydroloader==0.1.15
       - sqlalchemy-json==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django==4.1
 django-ninja==0.20.0
 django-ninja-jwt==5.2.5
-hydroserver-sensorthings==0.2.3
+hydroserver-sensorthings==0.2.4
 hydroloader==0.1.15
 dj-database-url==1.3.0
 python-decouple==3.7

--- a/stapi/urls.py
+++ b/stapi/urls.py
@@ -125,6 +125,11 @@ st_api_1_1 = SensorThingsAPI(
             body_schema=schemas.ObservationBody
         ),
         SensorThingsEndpoint(
+            name='create_observations',
+            authentication=[JWTAuth(), BasicAuth()],
+            body_schema=schemas.ObservationBody
+        ),
+        SensorThingsEndpoint(
             name='update_observation',
             deprecated=True,
             authorization=lambda request, observation_id, observation: False,

--- a/tests/test_sensorthings_endpoints.py
+++ b/tests/test_sensorthings_endpoints.py
@@ -140,7 +140,7 @@ def test_sensorthings_get_endpoints(
         'result': 23.2,
         'Datastream': {'@iot.id': '376be82c-b3a1-4d96-821b-c7954b931f94'}
     }, 201),
-    ('Observations', [{
+    ('CreateObservations', [{
         'Datastream': {'@iot.id': '376be82c-b3a1-4d96-821b-c7954b931f94'},
         'components': ['phenomenonTime', 'result'],
         'dataArray': [['2023-10-02T10:00:00Z', 24.5], ['2023-10-03T10:00:00Z', 22.8]]


### PR DESCRIPTION
I've updated the HydroServer SensorThings library to split up individual and dataArray observations POST requests between two endpoints (POST Observation and POST CreateObservations) rather than having them combined in one endpoint. This change helps bring our SensorThings API implementation more in line with the specification.