### PR TITLE
60 metadata query params

### DIFF
--- a/core/endpoints/datastream/schemas.py
+++ b/core/endpoints/datastream/schemas.py
@@ -1,9 +1,13 @@
 from ninja import Schema
 from pydantic import Field
-from typing import Union
+from typing import Union, List
 from uuid import UUID
 from datetime import datetime
 from sensorthings.validators import allow_partial
+from core.endpoints.observedproperty.schemas import ObservedPropertyGetResponse
+from core.endpoints.processinglevel.schemas import ProcessingLevelGetResponse
+from core.endpoints.unit.schemas import UnitGetResponse
+from core.endpoints.sensor.schemas import SensorGetResponse
 
 
 class DatastreamID(Schema):
@@ -51,3 +55,13 @@ class DatastreamPostBody(DatastreamFields):
 @allow_partial
 class DatastreamPatchBody(DatastreamFields):
     thing_id: UUID = Field(..., alias='thingId')
+
+
+class DatastreamMetadataGetResponse(Schema):
+    units: List[UnitGetResponse]
+    sensors: List[SensorGetResponse]
+    processing_levels: List[ProcessingLevelGetResponse] = Field(..., alias='processingLevels')
+    observed_properties: List[ObservedPropertyGetResponse] = Field(..., alias='observedProperties')
+
+    class Config:
+        allow_population_by_field_name = True

--- a/core/endpoints/datastream/views.py
+++ b/core/endpoints/datastream/views.py
@@ -24,14 +24,18 @@ router = DataManagementRouter(tags=['Datastreams'])
 
 
 @router.dm_list('', response=DatastreamGetResponse)
-def get_datastreams(request, modified_since: Optional[datetime] = None):
+def get_datastreams(request, modified_since: datetime = None, exclude_unowned: bool = False):
     """
     Get a list of Datastreams
 
     This endpoint returns a list of public Datastreams and Datastreams owned by the authenticated user if there is one.
     """
 
-    datastream_query, _ = query_datastreams(user=request.authenticated_user, modified_since=modified_since)
+    datastream_query, _ = query_datastreams(
+        user=request.authenticated_user,
+        modified_since=modified_since,
+        require_ownership=exclude_unowned
+    )
 
     return [
         build_datastream_response(datastream) for datastream in datastream_query.all()

--- a/core/endpoints/observedproperty/schemas.py
+++ b/core/endpoints/observedproperty/schemas.py
@@ -2,7 +2,6 @@ from ninja import Schema
 from uuid import UUID
 from typing import Optional
 from sensorthings.validators import allow_partial
-from accounts.schemas import UserFields
 
 
 class ObservedPropertyID(Schema):
@@ -18,7 +17,7 @@ class ObservedPropertyFields(Schema):
 
 
 class ObservedPropertyGetResponse(ObservedPropertyFields, ObservedPropertyID):
-    owner: Optional[UserFields]
+    owner: Optional[str]
 
     class Config:
         allow_population_by_field_name = True

--- a/core/endpoints/observedproperty/utils.py
+++ b/core/endpoints/observedproperty/utils.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from uuid import UUID
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from accounts.schemas import OrganizationFields, UserFields
 from core.models import Person, ObservedProperty
 from .schemas import ObservedPropertyFields
 
@@ -118,13 +117,7 @@ def get_observed_property_by_id(
 def build_observed_property_response(observed_property):
     return {
         'id': observed_property.id,
-        'owner': {
-            'organization': {
-                **{field: getattr(observed_property.person.organization, field, None)
-                   for field in OrganizationFields.__fields__.keys()}
-            } if observed_property.person.organization else None,
-            **{field: getattr(observed_property.person, field) for field in UserFields.__fields__.keys()}
-        } if observed_property.person else None,
+        'owner': observed_property.person.email if observed_property.person else None,
         **{field: getattr(observed_property, field) for field in ObservedPropertyFields.__fields__.keys()},
     }
 

--- a/core/endpoints/processinglevel/schemas.py
+++ b/core/endpoints/processinglevel/schemas.py
@@ -2,7 +2,6 @@ from ninja import Schema
 from uuid import UUID
 from typing import Optional
 from sensorthings.validators import allow_partial
-from accounts.schemas import UserFields
 
 
 class ProcessingLevelID(Schema):
@@ -16,7 +15,7 @@ class ProcessingLevelFields(Schema):
 
 
 class ProcessingLevelGetResponse(ProcessingLevelFields, ProcessingLevelID):
-    owner: Optional[UserFields]
+    owner: Optional[str]
 
     class Config:
         allow_population_by_field_name = True

--- a/core/endpoints/processinglevel/utils.py
+++ b/core/endpoints/processinglevel/utils.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from uuid import UUID
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from accounts.schemas import OrganizationFields, UserFields
 from core.models import Person, ProcessingLevel
 from .schemas import ProcessingLevelFields
 
@@ -118,13 +117,7 @@ def get_processing_level_by_id(
 def build_processing_level_response(processing_level):
     return {
         'id': processing_level.id,
-        'owner': {
-            'organization': {
-                **{field: getattr(processing_level.person.organization, field, None)
-                   for field in OrganizationFields.__fields__.keys()}
-            } if processing_level.person.organization else None,
-            **{field: getattr(processing_level.person, field) for field in UserFields.__fields__.keys()}
-        } if processing_level.person else None,
+        'owner': processing_level.person.email if processing_level.person else None,
         **{field: getattr(processing_level, field) for field in ProcessingLevelFields.__fields__.keys()},
     }
 

--- a/core/endpoints/resultqualifier/schemas.py
+++ b/core/endpoints/resultqualifier/schemas.py
@@ -2,7 +2,6 @@ from ninja import Schema
 from uuid import UUID
 from typing import Optional
 from sensorthings.validators import allow_partial
-from accounts.schemas import UserFields
 
 
 class ResultQualifierID(Schema):
@@ -15,7 +14,7 @@ class ResultQualifierFields(Schema):
 
 
 class ResultQualifierGetResponse(ResultQualifierFields, ResultQualifierID):
-    owner: Optional[UserFields]
+    owner: Optional[str]
 
     class Config:
         allow_population_by_field_name = True

--- a/core/endpoints/resultqualifier/utils.py
+++ b/core/endpoints/resultqualifier/utils.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 from uuid import UUID
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from accounts.schemas import OrganizationFields, UserFields
 from core.models import Person, ResultQualifier
 from .schemas import ResultQualifierFields
 
@@ -116,12 +115,6 @@ def get_result_qualifier_by_id(
 def build_result_qualifier_response(result_qualifier):
     return {
         'id': result_qualifier.id,
-        'owner': {
-            'organization': {
-                **{field: getattr(result_qualifier.person.organization, field, None)
-                   for field in OrganizationFields.__fields__.keys()}
-            } if result_qualifier.person.organization else None,
-            **{field: getattr(result_qualifier.person, field) for field in UserFields.__fields__.keys()}
-        } if result_qualifier.person else None,
+        'owner': result_qualifier.person.email if result_qualifier.person else None,
         **{field: getattr(result_qualifier, field) for field in ResultQualifierFields.__fields__.keys()},
     }

--- a/core/endpoints/sensor/schemas.py
+++ b/core/endpoints/sensor/schemas.py
@@ -3,7 +3,6 @@ from pydantic import Field
 from uuid import UUID
 from typing import Optional
 from sensorthings.validators import allow_partial
-from accounts.schemas import UserFields
 
 
 class SensorID(Schema):
@@ -23,7 +22,7 @@ class SensorFields(Schema):
 
 
 class SensorGetResponse(SensorFields, SensorID):
-    owner: Optional[UserFields]
+    owner: Optional[str]
 
     class Config:
         allow_population_by_field_name = True

--- a/core/endpoints/sensor/utils.py
+++ b/core/endpoints/sensor/utils.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from uuid import UUID
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from accounts.schemas import OrganizationFields, UserFields
 from core.models import Person, Sensor
 from .schemas import SensorFields
 
@@ -118,13 +117,7 @@ def get_sensor_by_id(
 def build_sensor_response(sensor):
     return {
         'id': sensor.id,
-        'owner': {
-            'organization': {
-                **{field: getattr(sensor.person.organization, field, None)
-                   for field in OrganizationFields.__fields__.keys()}
-            } if sensor.person.organization else None,
-            **{field: getattr(sensor.person, field) for field in UserFields.__fields__.keys()}
-        } if sensor.person else None,
+        'owner': sensor.person.email if sensor.person else None,
         **{field: getattr(sensor, field) for field in SensorFields.__fields__.keys()},
     }
 

--- a/core/endpoints/unit/schemas.py
+++ b/core/endpoints/unit/schemas.py
@@ -2,7 +2,6 @@ from ninja import Schema
 from uuid import UUID
 from typing import Optional
 from sensorthings.validators import allow_partial
-from accounts.schemas import UserFields
 
 
 class UnitID(Schema):
@@ -17,7 +16,7 @@ class UnitFields(Schema):
 
 
 class UnitGetResponse(UnitFields, UnitID):
-    owner: Optional[UserFields]
+    owner: Optional[str]
 
     class Config:
         allow_population_by_field_name = True

--- a/core/endpoints/unit/utils.py
+++ b/core/endpoints/unit/utils.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from uuid import UUID
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from accounts.schemas import OrganizationFields, UserFields
 from core.models import Person, Unit
 from .schemas import UnitFields
 
@@ -122,13 +121,7 @@ def get_unit_by_id(
 def build_unit_response(unit):
     return {
         'id': unit.id,
-        'owner': {
-            'organization': {
-                **{field: getattr(unit.person.organization, field, None)
-                   for field in OrganizationFields.__fields__.keys()}
-            } if unit.person.organization else None,
-            **{field: getattr(unit.person, field) for field in UserFields.__fields__.keys()}
-        } if unit.person else None,
+        'owner': unit.person.email if unit.person else None,
         **{field: getattr(unit, field) for field in UnitFields.__fields__.keys()},
     }
 

--- a/core/endpoints/unit/utils.py
+++ b/core/endpoints/unit/utils.py
@@ -48,7 +48,11 @@ def query_units(
         unit_query = unit_query.filter(id__in=unit_ids)
 
     if datastream_ids:
-        unit_query = unit_query.filter(datastreams__id__in=datastream_ids)
+        unit_query = unit_query.filter(
+            Q(datastreams__id__in=datastream_ids) |
+            Q(intended_time_spacing_units__id__in=datastream_ids) |
+            Q(time_aggregation_interval_units__id__in=datastream_ids)
+        )
 
     unit_query = unit_query.select_related('person', 'person__organization')
 


### PR DESCRIPTION
I've made the following changes to address the issue mentioned in https://github.com/hydroserver2/hydroserver/issues/60.

1. Added metadata endpoint to datastreams that returns metadata used by any given datastream.
2. Added query parameter to the datastream/metadata endpoint allowing the response to include all metadata that can be assigned to that datastream based on the primary owner.
3. Updated units response to include all units used in the datastream object.
4. Added query parameter to /datastreams to filter owned datastreams only.
5. Updated metadata endpoints to only return the owner's email instead of the full owner object.