### PR TITLE
Observations Query Optimization

### DIFF
--- a/core/endpoints/observations/utils.py
+++ b/core/endpoints/observations/utils.py
@@ -87,9 +87,9 @@ def query_observations(
     if feature_of_interest_ids:
         observation_query = observation_query.filter(feature_of_interest_id__in=feature_of_interest_ids)
 
-    observation_query = observation_query.select_related(
-        'datastream', 'feature_of_interest'
-    )
+    # observation_query = observation_query.select_related(
+    #     'datastream', 'feature_of_interest'
+    # )
 
     observation_query, result_exists = apply_observation_auth_rules(
         user=user,


### PR DESCRIPTION
Datastream and feature of interest fields are not currently being used in observations queries, so those extra fields will no longer be selected.