### PR TITLE
81 observations query fields

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 
   - pip:
       - Authlib==1.2.1
-      - hydroserver-sensorthings==0.2.5
+      - hydroserver-sensorthings==0.2.6
       - django-ninja-jwt==5.2.5
       - hydroloader==0.1.15
       - sqlalchemy-json==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django==4.1
 django-ninja==0.20.0
 django-ninja-jwt==5.2.5
-hydroserver-sensorthings==0.2.5
+hydroserver-sensorthings==0.2.6
 hydroloader==0.1.15
 dj-database-url==1.3.0
 python-decouple==3.7

--- a/stapi/engine/utils.py
+++ b/stapi/engine/utils.py
@@ -150,7 +150,7 @@ class SensorThingsUtils:
     def apply_rank(component, queryset, partition_field, filter_ids, max_records=100):
         """"""
 
-        total_query_limit = 10000  # TODO: Find a location in settings for this variable.
+        total_query_limit = 100000  # TODO: Find a location in settings for this variable.
 
         ranked_queryset = queryset.filter(
             **{f'{partition_field}__in': filter_ids}


### PR DESCRIPTION
- Increased server query limit to 100,000 for observations.
- Stopped SensorThings from generating related links and expanded fields for observations data arrays since they aren't used.