### PR TITLE
Added delete user endpoint and is_active filter to auth checks.

### DIFF
--- a/accounts/auth/basic.py
+++ b/accounts/auth/basic.py
@@ -6,7 +6,7 @@ from django.contrib.auth import authenticate
 class BasicAuth(HttpBasicAuth):
     def authenticate(self, request, username, password, *args, **kwargs):
         user = authenticate(email=username, password=password)
-        if user and user.is_authenticated:
+        if user and user.is_authenticated and user.is_active:
             request.authenticated_user = user
             return user
         elif username or password:

--- a/accounts/auth/jwt.py
+++ b/accounts/auth/jwt.py
@@ -18,6 +18,6 @@ class JWTAuth(JWTBaseAuthentication, HttpBearer):
         except AuthenticationFailed:
             user = None
 
-        if user and user.is_authenticated:
+        if user and user.is_authenticated and user.is_active:
             request.authenticated_user = user
             return user

--- a/accounts/views/users.py
+++ b/accounts/views/users.py
@@ -110,6 +110,22 @@ def update_user(request: HttpRequest, data: UserPatchBody):
     return build_user_response(user)
 
 
+@user_router.delete(
+    '/user',
+    response={
+        204: None
+    },
+    auth=[JWTAuth(), BasicAuth()],
+)
+def delete_user(request: HttpRequest):
+
+    user = getattr(request, 'authenticated_user', None)
+    user.is_active = False
+    user.save()
+
+    return 204, None
+
+
 @user_router.post(
     '/send-verification-email',
     auth=JWTAuth(),

--- a/core/endpoints/dataloader/utils.py
+++ b/core/endpoints/dataloader/utils.py
@@ -20,7 +20,7 @@ def apply_data_loader_auth_rules(
         raise HttpError(403, 'You are not authorized to access this Data Loader.')
 
     if user and require_ownership is True:
-        data_loader_query = data_loader_query.filter(Q(person=user))
+        data_loader_query = data_loader_query.filter((Q(person=user) & Q(person__is_active=True)))
 
     return data_loader_query, result_exists
 

--- a/core/endpoints/datasource/utils.py
+++ b/core/endpoints/datasource/utils.py
@@ -20,7 +20,7 @@ def apply_data_source_auth_rules(
         raise HttpError(403, 'You are not authorized to access this Data Source.')
 
     if user and require_ownership is True:
-        data_source_query = data_source_query.filter(Q(person=user))
+        data_source_query = data_source_query.filter((Q(person=user) & Q(person__is_active=True)))
 
     return data_source_query, result_exists
 

--- a/core/endpoints/datastream/utils.py
+++ b/core/endpoints/datastream/utils.py
@@ -31,7 +31,10 @@ def apply_datastream_auth_rules(
 
     result_exists = datastream_query.exists() if check_result is True else None
 
-    auth_filters = []
+    auth_filters = [
+        ~(Q(thing__associates__is_primary_owner=True) &
+          Q(thing__associates__person__is_active=False))
+    ]
 
     if ignore_privacy is False:
         if user:

--- a/core/endpoints/observations/utils.py
+++ b/core/endpoints/observations/utils.py
@@ -24,7 +24,10 @@ def apply_observation_auth_rules(
 
     result_exists = observation_query.exists() if check_result is True else None
 
-    auth_filters = []
+    auth_filters = [
+        ~(Q(datastream__thing__associates__is_primary_owner=True) &
+          Q(datastream__thing__associates__person__is_active=False))
+    ]
 
     if ignore_privacy is False:
         if user:

--- a/core/endpoints/observedproperty/utils.py
+++ b/core/endpoints/observedproperty/utils.py
@@ -23,9 +23,11 @@ def apply_observed_property_auth_rules(
         raise HttpError(403, 'You are not authorized to access this Observed Property.')
 
     if user and require_ownership is True:
-        observed_property_query = observed_property_query.filter(Q(person=user))
+        observed_property_query = observed_property_query.filter((Q(person=user) & Q(person__is_active=True)))
     elif user and require_ownership_or_unowned is True:
-        observed_property_query = observed_property_query.filter(Q(person=user) | Q(person=None))
+        observed_property_query = observed_property_query.filter(
+            (Q(person=user) & Q(person__is_active=True)) | Q(person=None)
+        )
     elif not user and require_ownership_or_unowned is True:
         observed_property_query = observed_property_query.filter(Q(person=None))
 

--- a/core/endpoints/processinglevel/utils.py
+++ b/core/endpoints/processinglevel/utils.py
@@ -23,9 +23,11 @@ def apply_processing_level_auth_rules(
         raise HttpError(403, 'You are not authorized to access this Processing Level.')
 
     if user and require_ownership is True:
-        processing_level_query = processing_level_query.filter(Q(person=user))
+        processing_level_query = processing_level_query.filter((Q(person=user) & Q(person__is_active=True)))
     elif user and require_ownership_or_unowned is True:
-        processing_level_query = processing_level_query.filter(Q(person=user) | Q(person=None))
+        processing_level_query = processing_level_query.filter(
+            (Q(person=user) & Q(person__is_active=True)) | Q(person=None)
+        )
     elif not user and require_ownership_or_unowned is True:
         processing_level_query = processing_level_query.filter(Q(person=None))
 

--- a/core/endpoints/resultqualifier/utils.py
+++ b/core/endpoints/resultqualifier/utils.py
@@ -21,9 +21,11 @@ def apply_result_qualifier_auth_rules(
         raise HttpError(403, 'You are not authorized to access this Result Qualifier.')
 
     if user and require_ownership is True:
-        result_qualifier_query = result_qualifier_query.filter(Q(person=user))
+        result_qualifier_query = result_qualifier_query.filter((Q(person=user) & Q(person__is_active=True)))
     elif user and require_ownership_or_unowned is True:
-        result_qualifier_query = result_qualifier_query.filter(Q(person=user) | Q(person=None))
+        result_qualifier_query = result_qualifier_query.filter(
+            (Q(person=user) & Q(person__is_active=True)) | Q(person=None)
+        )
     elif not user and require_ownership_or_unowned is True:
         result_qualifier_query = result_qualifier_query.filter(Q(person=None))
 

--- a/core/endpoints/sensor/utils.py
+++ b/core/endpoints/sensor/utils.py
@@ -23,11 +23,11 @@ def apply_sensor_auth_rules(
         raise HttpError(403, 'You are not authorized to access this Sensor.')
 
     if user and require_ownership is True:
-        sensor_query = sensor_query.filter(Q(person=user))
+        sensor_query = sensor_query.filter((Q(person=user) & Q(person__is_active=True)))
     elif user and require_ownership_or_unowned is True:
-        sensor_query = sensor_query.filter(Q(person=user) | Q(person=None))
+        sensor_query = sensor_query.filter((Q(person=user) & Q(person__is_active=True)) | Q(person=None))
     elif not user and require_ownership_or_unowned is True:
-        sensor_query = sensor_query.filter(Q(person=None))
+        sensor_query = sensor_query.filter((Q(person=user) & Q(person__is_active=True)))
 
     return sensor_query, result_exists
 

--- a/core/endpoints/thing/utils.py
+++ b/core/endpoints/thing/utils.py
@@ -25,7 +25,9 @@ def apply_thing_auth_rules(
 
     result_exists = thing_query.exists() if check_result is True else None
 
-    auth_filters = []
+    auth_filters = [
+        ~(Q(associates__is_primary_owner=True) & Q(associates__person__is_active=False))
+    ]
 
     if ignore_privacy is False:
         if user:
@@ -204,7 +206,7 @@ def build_thing_response(user, thing):
             **{field: getattr(associate.person, field) for field in PersonFields.__fields__.keys()},
             **{field: getattr(associate.person.organization, field, None)
                for field in OrganizationFields.__fields__.keys()},
-        } for associate in thing.associates.all() if associate.owns_thing is True],
+        } for associate in thing.associates.all() if associate.owns_thing is True and associate.person.is_active],
         **{field: getattr(thing, field) for field in ThingFields.__fields__.keys()},
         **{field: getattr(thing.location, field) for field in LocationFields.__fields__.keys()}
     }

--- a/core/endpoints/unit/utils.py
+++ b/core/endpoints/unit/utils.py
@@ -22,12 +22,12 @@ def apply_unit_auth_rules(
     if not user and require_ownership is True:
         raise HttpError(403, 'You are not authorized to access this Unit.')
     elif user and require_ownership_or_unowned is True:
-        unit_query = unit_query.filter(Q(person=user) | Q(person=None))
+        unit_query = unit_query.filter((Q(person=user) & Q(person__is_active=True)) | Q(person=None))
     elif not user and require_ownership_or_unowned is True:
         unit_query = unit_query.filter(Q(person=None))
 
     if user and require_ownership is True:
-        unit_query = unit_query.filter(Q(person=user))
+        unit_query = unit_query.filter(Q(person=user) & Q(person__is_active=True))
 
     return unit_query, result_exists
 


### PR DESCRIPTION
Added delete user endpoint. The endpoint will set the user as inactive, which will prevent the user from logging in and hide sites they are the primary owner of from all requests. Once we have a task scheduler set up, we can add a task to delete the user's data after 30 days.