### PR TITLE
103 sensorthings auth fix

### DIFF
--- a/stapi/engine/components/observed_properties.py
+++ b/stapi/engine/components/observed_properties.py
@@ -22,7 +22,7 @@ class ObservedPropertyEngine(ObservedPropertyBaseEngine, SensorThingsUtils):
         observed_properties, _ = query_observed_properties(
             user=getattr(getattr(self, 'request', None), 'authenticated_user', None),
             observed_property_ids=observed_property_ids,
-            require_ownership_or_unowned=not expanded
+            require_ownership_or_unowned=False if observed_property_ids is not None or not expanded else True
         )
 
         if filters:

--- a/stapi/engine/components/sensors.py
+++ b/stapi/engine/components/sensors.py
@@ -21,7 +21,7 @@ class SensorEngine(SensorBaseEngine, SensorThingsUtils):
         sensors, _ = query_sensors(
             user=getattr(getattr(self, 'request', None), 'authenticated_user', None),
             sensor_ids=sensor_ids,
-            require_ownership_or_unowned=not expanded
+            require_ownership_or_unowned=False if sensor_ids is not None or not expanded else True
         )
 
         if filters:


### PR DESCRIPTION
Updated SensorThings auth logic on observed properties and sensors to allow unauthenticated users to view any sensor or observed property by ID.