### PR TITLE
Added organizationName to SensorThings response.

### DIFF
--- a/stapi/engine/components/things.py
+++ b/stapi/engine/components/things.py
@@ -69,7 +69,8 @@ class ThingEngine(ThingBaseEngine, SensorThingsUtils):
                         {
                             'first_name': thing_association.person.first_name,
                             'last_name': thing_association.person.last_name,
-                            'email': thing_association.person.email
+                            'email': thing_association.person.email,
+                            'organization_name': getattr(thing_association.person.organization, 'name', None)
                         } for thing_association in thing.associates.all()
                     ]
                 },

--- a/stapi/schemas.py
+++ b/stapi/schemas.py
@@ -92,6 +92,7 @@ class ContactPerson(Schema):
     first_name: str = Field(..., alias='firstName')
     last_name: str = Field(..., alias='lastName')
     email: str = Field(..., alias='email')
+    organization_name: str = Field(None, alias='organizationName')
 
     class Config:
         allow_population_by_field_name = True


### PR DESCRIPTION
Addressing https://github.com/hydroserver2/hydroserver/issues/109

The SensorThings "Things" response will now include the organization name of the people in the contactPeople block.