### PR TITLE
Added lastUpdated field to SensorThings endpoints

### DIFF
--- a/stapi/engine/utils.py
+++ b/stapi/engine/utils.py
@@ -1,7 +1,8 @@
 from uuid import UUID
-from django.db.models import F, Window
+from django.db.models import F, Window, Prefetch
 from django.db.models.functions import DenseRank
 from django.core.exceptions import FieldError
+from django.db.models.query import prefetch_related_objects
 from ninja.errors import HttpError
 from odata_query.django.django_q import AstToDjangoQVisitor
 from core import models as core_models
@@ -161,10 +162,18 @@ class SensorThingsUtils:
 
         sql, params = ranked_queryset.query.sql_with_params()
 
-        query = getattr(core_models, component).objects.raw("""
+        query = list(getattr(core_models, component).objects.raw("""
             SELECT * FROM ({}) ranked_result
             WHERE rank <= %s
             LIMIT %s
-        """.format(sql), [*params, max_records, total_query_limit])
+        """.format(sql), [*params, max_records, total_query_limit]))
+
+        if hasattr(getattr(core_models, component), 'history'):
+            prefetch_related_objects(
+                query, Prefetch(
+                    'log',
+                    queryset=getattr(core_models, component).history.order_by('-history_date'), to_attr='ordered_log'
+                )
+            )
 
         return query

--- a/stapi/schemas.py
+++ b/stapi/schemas.py
@@ -1,7 +1,8 @@
 from uuid import UUID
 from ninja import Schema, Field
 from pydantic import HttpUrl
-from typing import List, Literal, Union
+from typing import List, Literal, Union, Optional
+from datetime import datetime
 from sensorthings import components as st_components
 
 
@@ -19,6 +20,7 @@ class DatastreamProperties(Schema):
     time_aggregation_interval_units: Union[st_components.UnitOfMeasurement, None] = Field(
         None, alias='timeAggregationIntervalUnitOfMeasurement'
     )
+    last_updated: Optional[datetime] = Field(None, alias='lastUpdated')
 
     class Config:
         allow_population_by_field_name = True
@@ -34,6 +36,7 @@ class LocationProperties(Schema):
     county: Union[str, None] = None
     elevation_m: Union[float, None] = None
     elevation_datum: Union[str, None] = Field(None, alias='elevationDatum')
+    last_updated: Optional[datetime] = Field(None, alias='lastUpdated')
 
     class Config:
         allow_population_by_field_name = True
@@ -46,6 +49,7 @@ class LocationResponse(Schema):
 class ObservedPropertyProperties(Schema):
     variable_code: str = Field(..., alias='variableCode')
     variable_type: str = Field(..., alias='variableType')
+    last_updated: Optional[datetime] = Field(None, alias='lastUpdated')
 
     class Config:
         allow_population_by_field_name = True
@@ -78,6 +82,7 @@ class SensorProperties(Schema):
     method_type: str = Field(..., alias='methodType')
     method_link: Union[HttpUrl, None] = Field(None, alias='methodLink')
     sensor_model: SensorModel = Field(..., alias='sensorModel')
+    last_updated: Optional[datetime] = Field(None, alias='lastUpdated')
 
     class Config:
         allow_population_by_field_name = True
@@ -103,6 +108,7 @@ class ThingProperties(Schema):
     sampling_feature_code: str = Field(..., alias='samplingFeatureCode')
     site_type: str = Field(..., alias='siteType')
     contact_people: List[ContactPerson] = Field(..., alias='contactPeople')
+    last_updated: Optional[datetime] = Field(None, alias='lastUpdated')
 
     class Config:
         allow_population_by_field_name = True


### PR DESCRIPTION
I've added a field called lastUpdated to the properties of the following SensorThings GET endpoints: Thing, Location, ObservedProperty, Sensor, and Datastream. The field shows a timestamp of the last time the object was modified based on the django-simple-history library.