### PR TITLE
108 option to restrict public accounts

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -18,14 +18,15 @@ accounts_api = NinjaExtraAPI(
 accounts_api.add_router(prefix='', router=user_router)
 accounts_api.register_controllers(HydroServerJWTController)
 
-if settings.AUTHLIB_OAUTH_CLIENTS.get('google', {}).get('client_id'):
-    accounts_api.add_router(prefix='google', router=google_router)
+if not settings.DISABLE_ACCOUNT_CREATION:
+    if settings.AUTHLIB_OAUTH_CLIENTS.get('google', {}).get('client_id'):
+        accounts_api.add_router(prefix='google', router=google_router)
 
-if settings.AUTHLIB_OAUTH_CLIENTS.get('orcid', {}).get('client_id'):
-    accounts_api.add_router(prefix='orcid', router=orcid_router)
+    if settings.AUTHLIB_OAUTH_CLIENTS.get('orcid', {}).get('client_id'):
+        accounts_api.add_router(prefix='orcid', router=orcid_router)
 
-if settings.AUTHLIB_OAUTH_CLIENTS.get('hydroshare', {}).get('client_id'):
-    accounts_api.add_router(prefix='hydroshare', router=hydroshare_router)
+    if settings.AUTHLIB_OAUTH_CLIENTS.get('hydroshare', {}).get('client_id'):
+        accounts_api.add_router(prefix='hydroshare', router=hydroshare_router)
 
 urlpatterns = [
     path('', accounts_api.urls),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,7 @@ from accounts.views.oauth.google import google_router
 from accounts.views.oauth.orcid import orcid_router
 from accounts.views.oauth.hydroshare import hydroshare_router
 from accounts.views.jwt import HydroServerJWTController
+from hydroserver import settings
 
 
 accounts_api = NinjaExtraAPI(
@@ -16,9 +17,15 @@ accounts_api = NinjaExtraAPI(
 
 accounts_api.add_router(prefix='', router=user_router)
 accounts_api.register_controllers(HydroServerJWTController)
-accounts_api.add_router(prefix='google', router=google_router)
-accounts_api.add_router(prefix='orcid', router=orcid_router)
-accounts_api.add_router(prefix='hydroshare', router=hydroshare_router)
+
+if settings.AUTHLIB_OAUTH_CLIENTS.get('google', {}).get('client_id'):
+    accounts_api.add_router(prefix='google', router=google_router)
+
+if settings.AUTHLIB_OAUTH_CLIENTS.get('orcid', {}).get('client_id'):
+    accounts_api.add_router(prefix='orcid', router=orcid_router)
+
+if settings.AUTHLIB_OAUTH_CLIENTS.get('hydroshare', {}).get('client_id'):
+    accounts_api.add_router(prefix='hydroshare', router=hydroshare_router)
 
 urlpatterns = [
     path('', accounts_api.urls),

--- a/hydroserver/settings.py
+++ b/hydroserver/settings.py
@@ -25,6 +25,7 @@ SECRET_KEY = config('SECRET_KEY', default='django-insecure-zw@4h#ol@0)5fxy=ib6(t
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', default=True, cast=bool)
 DEPLOYED = config('DEPLOYED', default=False, cast=bool)
+DISABLE_ACCOUNT_CREATION = config('DISABLE_ACCOUNT_CREATION', default=False, cast=bool)
 
 if DEPLOYED:
     hostname = socket.gethostname()


### PR DESCRIPTION
Added setting called DISABLE_ACCOUNT_CREATION that disables all account creation and OAuth login endpoints. Accounts can still be created by admin users through the admin dashboard. 